### PR TITLE
fix: enforce stricter renovate rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,9 @@
   "labels": ["dependencies"],
   "timezone": "Europe/Berlin",
   "ignorePaths": ["**/testdata/**"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
+  "internalChecksFilter": "strict",
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
- update internalChecksFilter to strict
- set minimumReleaseAge to 7 days
- enable OSV vulnerability alerts